### PR TITLE
Python type to owl type

### DIFF
--- a/nb2workflow/nbadapter.py
+++ b/nb2workflow/nbadapter.py
@@ -124,7 +124,18 @@ def parse_nbline(line: str, nb_uri=None) -> Optional[dict]:
 
 
 def owl_type_for_python_type(python_type: type):
-    return "http://www.w3.org/2001/XMLSchema#"+ python_type.__name__ 
+    out_type = python_type.__name__
+
+    if python_type == int:
+        out_type = 'integer'
+
+    if python_type == str:
+        out_type = 'string'
+
+    if python_type == bool:
+        out_type = 'boolean'
+
+    return "http://www.w3.org/2001/XMLSchema#" + out_type
 
 class InputParameter:
     raw_line=None 

--- a/nb2workflow/nbadapter.py
+++ b/nb2workflow/nbadapter.py
@@ -126,16 +126,27 @@ def parse_nbline(line: str, nb_uri=None) -> Optional[dict]:
 def owl_type_for_python_type(python_type: type):
     out_type = python_type.__name__
 
+    xml_scheme_url = "http://www.w3.org/2001/XMLSchema#"
+    oda_ontology_url = "http://odahub.io/ontology#"
+
     if python_type == int:
         out_type = 'integer'
-
-    if python_type == str:
+        url_prefix = xml_scheme_url
+    elif python_type == str:
         out_type = 'string'
-
-    if python_type == bool:
+        url_prefix = xml_scheme_url
+    elif python_type == bool:
         out_type = 'boolean'
+        url_prefix = xml_scheme_url
+    elif python_type == float:
+        out_type = 'float'
+        url_prefix = xml_scheme_url
+    else:
+        url_prefix = oda_ontology_url
 
-    return "http://www.w3.org/2001/XMLSchema#" + out_type
+    output_url = f"{url_prefix}{out_type}"
+
+    return output_url
 
 class InputParameter:
     raw_line=None 

--- a/tests/test_nbadapter.py
+++ b/tests/test_nbadapter.py
@@ -44,7 +44,7 @@ def test_nbadapter(test_notebook, morph_notebook, caplog):
     assert 'comment' in parameters['scwid']
     assert parameters['scwid']['owl_type'] == "http://odahub.io/ontology/integral#ScWID"
 
-    assert parameters['enabled']['owl_type'] == "http://www.w3.org/2001/XMLSchema#bool"
+    assert parameters['enabled']['owl_type'] == "http://www.w3.org/2001/XMLSchema#boolean"
 
     outputs = nba.extract_output_declarations()
     print("outputs", outputs)

--- a/tests/test_ontology.py
+++ b/tests/test_ontology.py
@@ -64,7 +64,9 @@ def test_nb2rdf(test_notebook_repo):
         assert (wfl_p_ns["scwid"], oda["value"], rdflib.Literal("066500110010.001")) in G
         assert (wfl_p_ns["scwid"], rdf_type, oda_integral["ScWID"]) in G
         assert (wfl_p_ns["nbins"], oda["value"], rdflib.Literal(100)) in G
-        assert (wfl_p_ns["nbins"], rdf_type, rdf_xmlschema["int"]) in G
+        assert (wfl_p_ns["nbins"], rdf_type, rdf_xmlschema["integer"]) in G
+        assert (wfl_p_ns["sleep"], oda["value"], rdflib.Literal(0)) in G
+        assert (wfl_p_ns["sleep"], rdf_type, rdf_xmlschema["integer"]) in G
 
         wfl_o_ns = rdflib.Namespace(wfl_o_ns_str.format(workflow_name=nba.unique_name))
         assert (wfl_o_ns["spectrum_png"], oda["value"], rdflib.Literal("fn")) in G

--- a/tests/test_semantic_comment.py
+++ b/tests/test_semantic_comment.py
@@ -135,14 +135,14 @@ def test_semantic_nbline():
     assert r['owl_type'] == "http://odahub.io/ontology#StartTimeISOT"
 
     r = parse_nbline("tstart_seconds=1 # oda:upper_limit 2") 
-    assert r['owl_type'] == "http://odahub.io/ontology#2integer_int_upper_limit"
+    assert r['owl_type'] == "http://odahub.io/ontology#2integer_integer_upper_limit"
     assert normalize(r['extra_ttl']) == normalize("""
         @prefix oda: <http://odahub.io/ontology#> . 
         @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> . 
         @prefix xsd: <http://www.w3.org/2001/XMLSchema#> . 
         @prefix owl: <http://www.w3.org/2002/07/owl#> . 
         
-        oda:2integer_int_upper_limit rdfs:subClassOf xsd:int;
+        oda:2integer_integer_upper_limit rdfs:subClassOf xsd:integer;
                                      oda:upper_limit 2 .
     """)
 


### PR DESCRIPTION
`owl_type_for_python_type` assigns proper owl type from the python type