### PR TITLE
ignore 'kubectl logs job/kaniko-build-*' error

### DIFF
--- a/nb2workflow/deploy.py
+++ b/nb2workflow/deploy.py
@@ -265,11 +265,15 @@ def _build_with_kaniko(git_origin,
                     if job_status[0].type == 'Complete':
                         break
                     if job_status[0].type == 'Failed':
-                        buildlog = sp.check_output([
-                            'kubectl',
-                            'logs',
-                            f"job/kaniko-build-{suffix}"
-                            ])
+                        try:
+                            buildlog = sp.check_output([
+                                'kubectl',
+                                'logs',
+                                f"job/kaniko-build-{suffix}"
+                                ])
+                        except sp.CalledProcessError:
+                            buildlog = None
+                            logger.error('Error getting buildlog from %s', f"job/kaniko-build-{suffix}")
                         raise ContainerBuildException('', buildlog)
             
         finally:


### PR DESCRIPTION
Getting job logs fails in some circumstances (to explore. I suspect this happened when build had failed due to disk pressure on a node). 

We don't want a user to get `Command '['kubectl', 'logs', 'job/kaniko-build-tmp5tcf3tt4']' returned non-zero exit status 1.` in the email, as it's completely internal 