### PR TITLE
dedicated sentry module with env var

### DIFF
--- a/nb2workflow/sentry.py
+++ b/nb2workflow/sentry.py
@@ -16,7 +16,8 @@ class Sentry:
 
     @property
     def sentry_url(self):
-        self._sentry_url = os.environ.get('SENTRY_URL', None)
+        if not hasattr(self, '_sentry_url'):
+            self._sentry_url = os.environ.get('SENTRY_URL', None)
         return self._sentry_url
 
     @property

--- a/nb2workflow/sentry.py
+++ b/nb2workflow/sentry.py
@@ -1,0 +1,49 @@
+import logging
+import os
+
+try:
+    import sentry_sdk
+except ImportError:
+    sentry_sdk = None
+except Exception as e:
+    logging.debug(f"an issue occurred while importing sentry: {repr(e)}")
+    sentry_sdk = None
+
+
+class Sentry:
+    def __init__(self) -> None:
+        self.logger = logging.getLogger(repr(self))
+
+    @property
+    def sentry_url(self):
+        self._sentry_url = os.environ.get('SENTRY_URL', None)
+        return self._sentry_url
+
+    @property
+    def have_sentry(self):
+        if self.sentry_url is None or sentry_sdk is None:
+            return False
+        else:
+            try:
+                sentry_sdk.init(dsn=self._sentry_url)
+            except Exception as ex:
+                self.logger.warning(f"can not setup sentry with URL {self.sentry_url} due to {repr(ex)}")
+
+            return True
+
+    def capture_message(self, message: str):
+        if self.have_sentry:
+            self.logger.warning(message)
+            sentry_sdk.capture_message(message)
+        else:
+            self.logger.warning("sentry not used, dropping %s", message)
+
+    def capture_exception(self, exception):
+        if self.have_sentry:
+            self.logger.warning(repr(exception))
+            sentry_sdk.capture_exception(exception)
+        else:
+            self.logger.warning("sentry not used, dropping %s", repr(exception))
+
+
+sentry = Sentry()

--- a/nb2workflow/sentry.py
+++ b/nb2workflow/sentry.py
@@ -17,7 +17,7 @@ class Sentry:
     @property
     def sentry_url(self):
         if not hasattr(self, '_sentry_url'):
-            self._sentry_url = os.environ.get('SENTRY_URL', None)
+            self._sentry_url = os.environ.get('SENTRY_URL', "https://63ae106793010d836c74830fa75b300c@o264756.ingest.sentry.io/4506186624335872")
         return self._sentry_url
 
     @property

--- a/nb2workflow/sentry.py
+++ b/nb2workflow/sentry.py
@@ -22,7 +22,7 @@ class Sentry:
 
     @property
     def have_sentry(self):
-        if self.sentry_url is None or sentry_sdk is None:
+        if self.sentry_url is None or self.sentry_url == '' or sentry_sdk is None:
             return False
         else:
             try:

--- a/nb2workflow/workflows.py
+++ b/nb2workflow/workflows.py
@@ -6,6 +6,7 @@ import datetime
 import logging
 from collections import OrderedDict
 from . import logstash
+from .sentry import sentry
 
 from diskcache import Cache
 
@@ -13,16 +14,6 @@ from nb2workflow import nbadapter
 
 cache = Cache('.nb2workflow/cache')
 enable_cache = False
-
-try:
-    import sentry_sdk
-    sentry_sdk.init(dsn="https://63ae106793010d836c74830fa75b300c@o264756.ingest.sentry.io/4506186624335872")
-except ImportError:
-    sentry_sdk = None
-except Exception as e:
-    import logging
-    logging.debug("big problem with sentry: %s",repr(e))
-    sentry_sdk = None
 
 logstasher = logstash.LogStasher()
 
@@ -156,8 +147,8 @@ def evaluate(router, *args, **kwargs):
                 logstasher.log(dict(event='problem evaluating',exception=repr(e)))
                 
                 if ntries <= 1:
-                    if sentry_sdk:
-                        sentry_sdk.capture_exception()
+                    if sentry.have_sentry:
+                        sentry.capture_exception(e)
                     raise
 
                 time.sleep(5)

--- a/nb2workflow/workflows.py
+++ b/nb2workflow/workflows.py
@@ -147,8 +147,7 @@ def evaluate(router, *args, **kwargs):
                 logstasher.log(dict(event='problem evaluating',exception=repr(e)))
                 
                 if ntries <= 1:
-                    if sentry.have_sentry:
-                        sentry.capture_exception(e)
+                    sentry.capture_exception(e)
                     raise
 
                 time.sleep(5)


### PR DESCRIPTION
in order to have sentry configurable, the `dsn`, with this, it will be read from an env var

the idea is to use a similar approach to the one implemented within the dispatcher