### PR TITLE
Tune probes timeouts of deployment

### DIFF
--- a/nb2workflow/templates/deployment.yaml.jinja
+++ b/nb2workflow/templates/deployment.yaml.jinja
@@ -46,24 +46,24 @@ spec:
         {% endfor %}
         {% endif %}
         startupProbe:
-          failureThreshold: 3
+          failureThreshold: 10
           httpGet:
             path: /health
             port: 8000
             scheme: HTTP
-          initialDelaySeconds: 5
-          periodSeconds: 5
+          initialDelaySeconds: 10
+          periodSeconds: 10
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 2
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: 6
           httpGet:
             path: /health
             port: 8000
             scheme: HTTP
-          periodSeconds: 30
+          periodSeconds: 10
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 2
       restartPolicy: Always
       {% if with_volume %}
       volumes:


### PR DESCRIPTION
The main reason is to give more time for the container to start. StartupProbe failed too early