### PR TITLE
Kaniko pod antiaffinity

### DIFF
--- a/nb2workflow/deploy.py
+++ b/nb2workflow/deploy.py
@@ -267,7 +267,10 @@ class NBRepo:
                           build_timestamp: bool = False,
                           namespace: str = "oda-staging",
                           cleanup: bool = True,
-                          nb2wversion=version(print_it=False)) -> dict:
+                          nb2wversion=version(print_it=False),
+                          kaniko_pod_antiaffinity=True,
+                          dispatcher_app_label='oda-dispatcher',
+                          frontend_app_label='frontend') -> dict:
        
         #secret should be created beforehand https://github.com/GoogleContainerTools/kaniko#pushing-to-docker-hub
         
@@ -291,7 +294,10 @@ class NBRepo:
                 suffix = suffix,
                 namespace = namespace,
                 no_push = no_push,
-                image = image
+                image = image,
+                kaniko_pod_antiaffinity = kaniko_pod_antiaffinity,
+                dispatcher_app_label = dispatcher_app_label,
+                frontend_app_label = frontend_app_label
             ))
 
         tmpl = jenv.get_template('dockerfile_cm.yaml.jinja')

--- a/nb2workflow/templates/buildjob.yaml.jinja
+++ b/nb2workflow/templates/buildjob.yaml.jinja
@@ -8,6 +8,19 @@ spec:
   ttlSecondsAfterFinished: 86400                
   template:
     spec:
+      {% if kaniko_pod_antiaffinity %}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                - {{ dispatcher_app_label }}
+                - {{ frontend_app_label }}
+            topologyKey: "kubernetes.io/hostname"
+      {% endif %}
       containers:
       - name: kaniko-build
         image: gcr.io/kaniko-project/executor:v1.22.0


### PR DESCRIPTION
Prevent placing kaniko pod on nodes where dispatcher and frontend run. 
Will reduce the impact of possible node ephemeral storage overflow on main components