### PR TITLE
Restrict micromamba version < 2.0

### DIFF
--- a/nb2workflow/service.py
+++ b/nb2workflow/service.py
@@ -26,6 +26,7 @@ import datetime
 import tempfile
 import nbformat
 import yaml
+import traceback
 
 from io import BytesIO
 from bs4 import BeautifulSoup
@@ -153,7 +154,7 @@ class AsyncWorkflow:
         try:
             self._run()
         except Exception as e:
-            logger.error("run failed unexplicably: %s", repr(e))
+            logger.error("run failed inexplicably: %s\n%s", repr(e), traceback.format_exc())
             app.async_workflows[self.key] = dict(
                 output={}, 
                 exceptions=[serialize_workflow_exception(e)]

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,6 @@ setup(name='nb2workflow',
             'Jinja2'
         ],
         'galaxy':[
-            'ensureconda',
             'bibtexparser >= 2.0.0b3',
             'pypandoc_binary',
             'black',

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -172,5 +172,7 @@ def test_service_async_repo(client):
 
     test_worker_thread.join()
 
+    logger.info("output has keys: %s", list(r.json['data']['output']))
+        
     open("output.png","wb").write(base64.b64decode(r.json['data']['output']['spectrum_png_content']))
     


### PR DESCRIPTION
Newer micromamba fails with 
`error    libmamba Expected environment not found at prefix: /root/.local/share/mamba
`
when `micromamba search ...`.

There is no upper version limit in ensureconda, so just load specific release directly.