### PR TITLE
Default dispatcher label (for kaniko pod antiaffinity)

### DIFF
--- a/nb2workflow/deploy.py
+++ b/nb2workflow/deploy.py
@@ -269,7 +269,7 @@ class NBRepo:
                           cleanup: bool = True,
                           nb2wversion=version(print_it=False),
                           kaniko_pod_antiaffinity=True,
-                          dispatcher_app_label='oda-dispatcher',
+                          dispatcher_app_label='dispatcher',
                           frontend_app_label='frontend') -> dict:
        
         #secret should be created beforehand https://github.com/GoogleContainerTools/kaniko#pushing-to-docker-hub


### PR DESCRIPTION
It's configurable, so better to update the code of oda-bot.  But this PR is the minimal way, and  the default should coincide anyway with https://github.com/oda-hub/dispatcher-chart/blob/d7567ea88f1be420b6289fde1afb248eaf97f0bb/templates/_helpers.tpl#L38C1-L38C53

