### PR TITLE
Better check for job completion condition

### DIFF
--- a/nb2workflow/deploy.py
+++ b/nb2workflow/deploy.py
@@ -320,9 +320,9 @@ class NBRepo:
                 time.sleep(10)
                 job_status = check_job_status(f"kaniko-build-{suffix}", namespace)
                 if job_status is not None:
-                    if job_status[0].type == 'Complete':
+                    if 'Complete' in [x.type for x in job_status]:
                         break
-                    if job_status[0].type == 'Failed':
+                    if 'Failed' in [x.type for x in job_status]:
                         try:
                             buildlog = sp.check_output([
                                 'kubectl',


### PR DESCRIPTION
k8s job status conditions may contain several items so a check for it needs to be adapted.
Seems to be dependent of k8s version, the bot now gets stuck after k8s update