### PR TITLE
Use GITHUB_TOKEN in checkout of bump version

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-        token: ${{ secrets.ODA_BOT_SECRET }}
+        token: ${{ secrets.GITHUB_TOKEN }}
       #     persist-credentials: false
 
     - name: Install dependencies


### PR DESCRIPTION
If I don't miss something, no need for an additional token here.

It's probably expired, leading to failure https://github.com/oda-hub/nb2workflow/actions/runs/13010628641
