### PR TITLE
Hotfix yq decoding unicode sequence

### DIFF
--- a/nb2workflow/templates/Dockerfile.jinja
+++ b/nb2workflow/templates/Dockerfile.jinja
@@ -48,6 +48,6 @@ ENV ODA_WORKFLOW_LAST_AUTHOR="{{ metadata['author'] }}"
 ENV ODA_WORKFLOW_LAST_CHANGED="{{ metadata['last_change_time'] }}"
 
 RUN for nn in {{ nbpath }}/*.ipynb; do \
-    /tmp/yq -i '.metadata.kernelspec.name |= "python3"' $nn; done
+    /tmp/yq -i -p json -o json '.metadata.kernelspec.name |= "python3"' $nn; done
 
 CMD nb2service --debug --pattern '{{ filename_pattern }}' --host 0.0.0.0 --port 8000 {{ nbpath }}


### PR DESCRIPTION
When not explicitly specifying the formats, `yq` (used to inject kernel name into nb) corrupts notebook by decoding unicode sequences.

Caused problems deploying [karabo notebook](https://gitlab.renkulab.io/astronomy/mmoda/karabo-dirty-image-sim/-/blob/a7188e346d82da8ed2f592de0ed62210ae7b5588/karabo-workflow.ipynb) with coloured output in the cell 