### PR TITLE
Revert "Use GITHUB_TOKEN in checkout of bump version"

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.ODA_BOT_SECRET }}
       #     persist-credentials: false
 
     - name: Install dependencies


### PR DESCRIPTION
Reverts oda-hub/nb2workflow#231