### PR TITLE
Update deprecated OS version and bump action versions in workflows 

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -10,11 +10,11 @@ on:
 jobs:
   bump-version:
     name: Bump package version
-    if: "!contains(github.event.head_commit.message, 'Bump version')"
-    runs-on: ubuntu-20.04
+    if: ${{ !contains(github.event.head_commit.message, 'Bump version') }}
+    runs-on: ubuntu-latest
     steps:
     - name: actions/checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
         token: ${{ secrets.ODA_BOT_SECRET }}
@@ -42,8 +42,8 @@ jobs:
       run: python -m build
 
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      uses: pypa/gh-action-pypi-publish@v1.12.4
       with:
         user: __token__
-        verify_metadata: false
+        verify-metadata: false
         password: ${{ secrets.PYPI_API_TOKEN }}        

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Python package
+name: Python test
 
 on:
   push:
@@ -18,10 +18,10 @@ jobs:
         python-version-env: [py39]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
 


### PR DESCRIPTION
Following https://github.com/actions/runner-images/issues/11101 "Bump version"" workflow stopped working, preventing package publishing. Also updated ancient versions of actions.